### PR TITLE
Revert "Bump cefpython3 from 66.0 to 66.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cefpython3==66.1
+cefpython3==66.0
 charset-normalizer==3.3.2
 idna==3.6
 PyATEMMax==1.0b9


### PR DESCRIPTION
Reverts mackenly/PyATEMAPI#51
Version bump caused build errors installing packages.