### PR TITLE
60 resolve CWE 214 and docker compose env bug

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -40,7 +40,8 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: mackenly/pyatemapi:${{ steps.previoustag.outputs.tag }}
+          # images: mackenly/pyatemapi:${{ steps.previoustag.outputs.tag }}
+          images: nuvious/pyatemapi:${{ steps.previoustag.outputs.tag }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -48,7 +49,8 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: mackenly/pyatemapi:${{ steps.previoustag.outputs.tag }}
+          tags: nuvious/pyatemapi:${{ steps.previoustag.outputs.tag }}
+          # tags: mackenly/pyatemapi:${{ steps.previoustag.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
 
@@ -57,5 +59,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: mackenly/pyatemapi
+          # repository: mackenly/pyatemapi
+          repository: nuvious/pyatemapi
           short-description: "A rest API server for Black Magic Design ATEM switchers."

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -40,8 +40,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          # images: mackenly/pyatemapi:${{ steps.previoustag.outputs.tag }}
-          images: nuvious/pyatemapi:${{ steps.previoustag.outputs.tag }}
+          images: mackenly/pyatemapi:${{ steps.previoustag.outputs.tag }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -49,8 +48,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: nuvious/pyatemapi:${{ steps.previoustag.outputs.tag }}
-          # tags: mackenly/pyatemapi:${{ steps.previoustag.outputs.tag }}
+          tags: mackenly/pyatemapi:${{ steps.previoustag.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
 
@@ -59,6 +57,5 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          # repository: mackenly/pyatemapi
-          repository: nuvious/pyatemapi
+          repository: mackenly/pyatemapi
           short-description: "A rest API server for Black Magic Design ATEM switchers."

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ COPY requirements.txt /app/
 RUN python3 -m pip install --upgrade pip>=23.3.2 && \
     pip3 install -r /app/requirements.txt
 COPY . .
-RUN chmod +x entrypoint.sh
+RUN chmod +x server.py
 
 EXPOSE 5555
 
-ENTRYPOINT ["/app/entrypoint.sh"]
+ENTRYPOINT [ "/usr/local/bin/python3" ]
+CMD ["/app/server.py"]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Clone PyATEMAPI to your machine by running:
 
 `git clone https://github.com/mackenly/PyATEMAPI.git`
 
+Install the required packages by running:
+
+`pip install -r requirements.txt`
+
 While in the directory of the project, run server.py to start the server. Pass in as parameters the IP address of the ATEM switcher and a simple passphrase for basic authentication. If running on native python, best practice is to read these variables in with the `read` command in Linux/Mac or the `Read-Host` command in Windows:
 
 ### Linux/Mac

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 services:
   pyatemapi:
-    image: mackenly/pyatemapi
+    image: temp
     ports:
       - "5555:5555"
+    environment:
+      - SERVER_IP
+      - PASSPHRASE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   pyatemapi:
-    image: temp
+    image: mackenly/pyatemapi
     ports:
       - "5555:5555"
     environment:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-set -x
-# Variable precedence is environment variable defined, then command line supplied,
-# and finally default values.
-SERVER_IP="${SERVER_IP:-${1:-127.0.0.1}}"
-PASSPHRASE="${PASSPHRASE:-${2:-Password1}}"
-python server.py $SERVER_IP $PASSPHRASE

--- a/server.py
+++ b/server.py
@@ -3,6 +3,7 @@
 # Web: mackenly.com
 # Twitter: @mackenlyjones
 
+import os
 import argparse
 import logging
 import json
@@ -104,18 +105,18 @@ class GFG(BaseHTTPRequestHandler):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('ip', help='switcher IP address')
-    parser.add_argument('passphrase', help='passphrase to compare requests to', type=str, default='Password1')
+    parser.add_argument('--ip', help='switcher IP address', default='127.0.0.1')
+    parser.add_argument('--passphrase', help='passphrase to compare requests to', type=str, default='Password1')
     args = parser.parse_args()
 
     # set global variables
     global passphrase, ip
-    passphrase = args.passphrase
-    ip = args.ip
+    passphrase = os.environ.get('PASSPHRASE', args.passphrase)
+    ip = os.environ.get('SERVER_IP', args.ip)
 
     log.info("Initializing switcher")
     switcher.setLogLevel(logging.INFO) # Set switcher verbosity (try DEBUG to see more)
-    switcher.connect(args.ip)
+    switcher.connect(ip)
 
     log.info("Waiting for connection")
     switcher.waitForConnection()

--- a/server.py
+++ b/server.py
@@ -14,8 +14,8 @@ from http.server import *
 # create the switcher object
 switcher = PyATEMMax.ATEMMax()
 api = Api(switcher)
-passphrase = 'Password1'
-ip = '127.0.0.1'
+passphrase = ''
+ip = ''
 
 
 class GFG(BaseHTTPRequestHandler):
@@ -105,7 +105,7 @@ class GFG(BaseHTTPRequestHandler):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--ip', help='switcher IP address', default='127.0.0.1')
+    parser.add_argument('--ip', help='switcher IP address')
     parser.add_argument('--passphrase', help='passphrase to compare requests to', type=str, default='Password1')
     args = parser.parse_args()
 
@@ -113,6 +113,11 @@ def main():
     global passphrase, ip
     passphrase = os.environ.get('PASSPHRASE', args.passphrase)
     ip = os.environ.get('SERVER_IP', args.ip)
+
+    # if no ip is provided, exit
+    if ip is None:
+        log.error("No IP address provided")
+        exit()
 
     log.info("Initializing switcher")
     switcher.setLogLevel(logging.INFO) # Set switcher verbosity (try DEBUG to see more)
@@ -131,7 +136,7 @@ def main():
     # this is used for running our
     # server as long as we wish
     # i.e. forever
-    print("Starting server on http://localhost:" + str(port.server_port))
+    log.info("Starting API server on http://localhost:" + str(port.server_port))
     port.serve_forever()
 
 
@@ -143,4 +148,13 @@ logging.basicConfig( datefmt='%H:%M:%S',
 log = logging.getLogger('PyATEMAPI')
 
 # run main to start the connection and server
-main()
+try:
+    main()
+except KeyboardInterrupt:
+    log.info("Exiting from keyboard interrupt")
+    switcher.disconnect()
+    exit()
+except Exception as e:
+    log.error("An error occurred: " + str(e))
+    switcher.disconnect()
+    exit()


### PR DESCRIPTION
Resolved CWE-214 issue, docker-compose env variable issue (wouldn't read from .env without the specific env vars declared) and updated README accordingly.

To make the command line arguments optional, I had to switch them to named arguments. That changes the command invocation (if not using environment vars) from:
```bash
python server.py IP PASSPHRASE
```
to:
```bash
python server.py --ip IP --passphrase PASSPHRASE
```

This is a breaking change technically but resolves the issues with CWE-214 and environment variables are generally a better practice for holding sensitive info like plaintext passphrases. Standing by for questions, direction, or questions.

P.S. This change was built and tested and the `nuvious/pyatemapi:dev` image can be pulled for direct testing if desired.